### PR TITLE
Prevent conflicts if multiple plugins are running the polyfill

### DIFF
--- a/wp-admin-tabbed-settings-pages.php
+++ b/wp-admin-tabbed-settings-pages.php
@@ -12,16 +12,19 @@
  *
  * Note that the Trac version uses "settings-tabs" as the hook to prevent conflict.
  */
-function wp_admin_tabbed_settings_register_script() {
-	wp_register_script(
-		'wp-admin-tabs',
-		plugins_url( 'assets/tabs.js', __FILE__ ),
-		array(),
-		'0.1.0',
-		true
-	);
+if ( ! function_exists( 'wp_admin_tabbed_settings_register_script' ) ) {
+	function wp_admin_tabbed_settings_register_script() {
+		wp_register_script(
+			'wp-admin-tabs',
+			plugins_url( 'assets/tabs.js', __FILE__ ),
+			array(),
+			'0.1.0',
+			true
+		);
+	}
+
+	add_action( 'admin_enqueue_scripts', 'wp_admin_tabbed_settings_register_script', 1 );
 }
-add_action( 'admin_enqueue_scripts', 'wp_admin_tabbed_settings_register_script', 1 );
 
 if ( ! function_exists( 'do_tabbed_settings_sections' ) ) {
 	/**


### PR DESCRIPTION
The `do_tabbed_settings_sections()` function is wrapped in a `function_exists()` check, but the `wp_admin_tabbed_settings_register_script()` function was not.