### PR TITLE
Prevent <section> elements from being broken if no fields are registered for a setting

### DIFF
--- a/wp-admin-tabbed-settings-pages.php
+++ b/wp-admin-tabbed-settings-pages.php
@@ -72,12 +72,12 @@ if ( ! function_exists( 'do_tabbed_settings_sections' ) ) {
 				call_user_func( $section['callback'], $section );
 			}
 
-			if ( ! isset( $wp_settings_fields[ $page ][ $section['id'] ] ) ) {
-				continue;
+			if ( isset( $wp_settings_fields[ $page ][ $section['id'] ] ) ) {
+				echo '<table class="form-table" role="presentation">';
+				do_settings_fields( $page, $section['id'] );
+				echo '</table>';
 			}
-			echo '<table class="form-table" role="presentation">';
-			do_settings_fields( $page, $section['id'] );
-			echo '</table>';
+
 			echo '</section>';
 		}
 


### PR DESCRIPTION
If `$wp_settings_fields[$page][$section['id']]` isn't set, there's no reason to render the `.form-table`, but we **always** need to close the `<section>` element.