### PR TITLE
Version 0.1.2

### DIFF
--- a/wp-admin-tabbed-settings-pages.php
+++ b/wp-admin-tabbed-settings-pages.php
@@ -4,7 +4,7 @@
  * Description: A polyfill for Trac #51086, bringing tabbed settings pages into WP-Admin.
  * Author:      Steve Grunwell
  * Author URI:  https://stevegrunwell.com
- * Version:     0.1.1
+ * Version:     0.1.2
  */
 
 /**
@@ -18,7 +18,7 @@ if ( ! function_exists( 'wp_admin_tabbed_settings_register_script' ) ) {
 			'wp-admin-tabs',
 			plugins_url( 'assets/tabs.js', __FILE__ ),
 			array(),
-			'0.1.1',
+			'0.1.2',
 			true
 		);
 	}


### PR DESCRIPTION
## Fixed

* Prevent `<section>` elements from being broken if no fields are registered for a setting (#11)