### PR TITLE
Prevent the tab content from displaying before the tab script is loaded

### DIFF
--- a/assets/tabs.js
+++ b/assets/tabs.js
@@ -24,6 +24,7 @@
 		panels.forEach(function (panel) {
 			if (panel.getAttribute('aria-labelledby') === tabId) {
 				panel.removeAttribute('hidden');
+				panel.classList.remove('hide-if-js');
 			} else {
 				panel.setAttribute('hidden', true);
 			}

--- a/tests/test-tabbed-settings-sections.php
+++ b/tests/test-tabbed-settings-sections.php
@@ -64,7 +64,7 @@ class TabbedSettingsSections extends WP_UnitTestCase {
 			'<a href="#tabbed-settings-1" id="nav-tab-tabbed-settings-1" class="nav-tab" role="tab">Tabbed settings 1</a>',
 			$output
 		);
-		$this->assertContains( '<section id="tab-tabbed-settings-1" role="tabpanel"', $output );
+		$this->assertContains( '<section id="tab-tabbed-settings-1" class="hide-if-js" role="tabpanel"', $output );
 
 		$this->assertTrue(
 			wp_script_is( 'wp-admin-tabs', 'enqueued' ),
@@ -89,7 +89,7 @@ class TabbedSettingsSections extends WP_UnitTestCase {
 			'<a href="#tabbed-settings-1" id="nav-tab-tabbed-settings-1" class="nav-tab" role="tab">Tabbed settings 1</a>',
 			$output
 		);
-		$this->assertNotContains( '<section id="tab-tabbed-settings-1" role="tabpanel"', $output );
+		$this->assertNotContains( '<section id="tab-tabbed-settings-1" class="hide-if-js" role="tabpanel"', $output );
 
 		$this->assertFalse(
 			wp_script_is( 'settings-tabs', 'enqueued' ),

--- a/wp-admin-tabbed-settings-pages.php
+++ b/wp-admin-tabbed-settings-pages.php
@@ -63,7 +63,7 @@ if ( ! function_exists( 'do_tabbed_settings_sections' ) ) {
 		echo '</nav>';
 
 		foreach ( (array) $wp_settings_sections[ $page ] as $section ) {
-			printf( '<section id="tab-%1$s" role="tabpanel" aria-labelledby="nav-tab-%1$s">', esc_attr( $section['id'] ) );
+			printf( '<section id="tab-%1$s" class="hide-if-js" role="tabpanel" aria-labelledby="nav-tab-%1$s">', esc_attr( $section['id'] ) );
 			if ( $section['title'] ) {
 				printf( '<h2>%1$s</h2>%2$s', esc_html( $section['title'] ), PHP_EOL );
 			}


### PR DESCRIPTION
Using WordPress' `.hide-if-js` class, hide all of the tab panels by default and remove the class (if it's still set) at the time the tab is first rendered. This prevents the "flash" of the tab contents as the page is loading.