### PR TITLE
Add a class name to each tab panel's <h2>

### DIFF
--- a/wp-admin-tabbed-settings-pages.php
+++ b/wp-admin-tabbed-settings-pages.php
@@ -65,7 +65,7 @@ if ( ! function_exists( 'do_tabbed_settings_sections' ) ) {
 		foreach ( (array) $wp_settings_sections[ $page ] as $section ) {
 			printf( '<section id="tab-%1$s" role="tabpanel" aria-labelledby="nav-tab-%1$s">', esc_attr( $section['id'] ) );
 			if ( $section['title'] ) {
-				printf( '<h2>%1$s</h2>%2$s', esc_html( $section['title'] ), PHP_EOL );
+				printf( '<h2 class="tabbed-section-heading">%1$s</h2>%2$s', esc_html( $section['title'] ), PHP_EOL );
 			}
 
 			if ( is_callable( $section['callback'] ) ) {


### PR DESCRIPTION
Some implementations may wish to hide the `<h2>` by default, so this provides something for custom styles to hook onto.