### PR TITLE
Version 0.2.0

### DIFF
--- a/assets/tabs.js
+++ b/assets/tabs.js
@@ -24,6 +24,7 @@
 		panels.forEach(function (panel) {
 			if (panel.getAttribute('aria-labelledby') === tabId) {
 				panel.removeAttribute('hidden');
+				panel.classList.remove('hide-if-js');
 			} else {
 				panel.setAttribute('hidden', true);
 			}

--- a/assets/tabs.js
+++ b/assets/tabs.js
@@ -30,6 +30,17 @@
 		});
 	}
 
+	/**
+	 * Get the ID of the active tab.
+	 *
+	 * @return {string} The ID of the active tab.
+	 */
+	function getActiveTab() {
+		var active = tabWrapper.querySelector('.nav-tab-active') || tabs[0];
+
+		return active.id || '';
+	}
+
 	// Return early if there are no tabs on the page.
 	if (! tabs || ! panels) {
 		return;
@@ -39,7 +50,7 @@
 	var currentTab = window.location.hash.substr(1);
 	currentTab = currentTab ? 'nav-tab-' + currentTab : tabs[0].getAttribute('id');
 
-	// Set the current tab and register the event listener.
+	// Set the current tab and register the event listeners.
 	setActiveTab(currentTab);
 	tabWrapper.addEventListener('click', function (e) {
 		if ('A' !== e.target.tagName) {
@@ -47,5 +58,14 @@
 		}
 
 		setActiveTab(e.target.id);
-	})
+	});
+
+	// Listen for other changes to the window hash.
+	window.addEventListener('hashchange', function () {
+		var id = window.location.hash.substr(1);
+
+		if (id !== getActiveTab()) {
+			setActiveTab('nav-tab-' + id);
+		}
+	});
 }(window, document));

--- a/tests/test-tabbed-settings-sections.php
+++ b/tests/test-tabbed-settings-sections.php
@@ -64,7 +64,7 @@ class TabbedSettingsSections extends WP_UnitTestCase {
 			'<a href="#tabbed-settings-1" id="nav-tab-tabbed-settings-1" class="nav-tab" role="tab">Tabbed settings 1</a>',
 			$output
 		);
-		$this->assertContains( '<section id="tab-tabbed-settings-1" role="tabpanel"', $output );
+		$this->assertContains( '<section id="tab-tabbed-settings-1" class="hide-if-js" role="tabpanel"', $output );
 
 		$this->assertTrue(
 			wp_script_is( 'wp-admin-tabs', 'enqueued' ),
@@ -89,7 +89,7 @@ class TabbedSettingsSections extends WP_UnitTestCase {
 			'<a href="#tabbed-settings-1" id="nav-tab-tabbed-settings-1" class="nav-tab" role="tab">Tabbed settings 1</a>',
 			$output
 		);
-		$this->assertNotContains( '<section id="tab-tabbed-settings-1" role="tabpanel"', $output );
+		$this->assertNotContains( '<section id="tab-tabbed-settings-1" class="hide-if-js" role="tabpanel"', $output );
 
 		$this->assertFalse(
 			wp_script_is( 'settings-tabs', 'enqueued' ),

--- a/wp-admin-tabbed-settings-pages.php
+++ b/wp-admin-tabbed-settings-pages.php
@@ -65,7 +65,7 @@ if ( ! function_exists( 'do_tabbed_settings_sections' ) ) {
 		foreach ( (array) $wp_settings_sections[ $page ] as $section ) {
 			printf( '<section id="tab-%1$s" role="tabpanel" aria-labelledby="nav-tab-%1$s">', esc_attr( $section['id'] ) );
 			if ( $section['title'] ) {
-				printf( '<h2>%1$s</h2>%2$s', esc_html( $section['title'] ), PHP_EOL );
+				printf( '<h2 class="tabbed-section-heading">%1$s</h2>%2$s', esc_html( $section['title'] ), PHP_EOL );
 			}
 
 			if ( is_callable( $section['callback'] ) ) {

--- a/wp-admin-tabbed-settings-pages.php
+++ b/wp-admin-tabbed-settings-pages.php
@@ -4,7 +4,7 @@
  * Description: A polyfill for Trac #51086, bringing tabbed settings pages into WP-Admin.
  * Author:      Steve Grunwell
  * Author URI:  https://stevegrunwell.com
- * Version:     0.1.2
+ * Version:     0.2.0
  */
 
 /**
@@ -18,7 +18,7 @@ if ( ! function_exists( 'wp_admin_tabbed_settings_register_script' ) ) {
 			'wp-admin-tabs',
 			plugins_url( 'assets/tabs.js', __FILE__ ),
 			array(),
-			'0.1.2',
+			'0.2.0',
 			true
 		);
 	}

--- a/wp-admin-tabbed-settings-pages.php
+++ b/wp-admin-tabbed-settings-pages.php
@@ -63,7 +63,7 @@ if ( ! function_exists( 'do_tabbed_settings_sections' ) ) {
 		echo '</nav>';
 
 		foreach ( (array) $wp_settings_sections[ $page ] as $section ) {
-			printf( '<section id="tab-%1$s" role="tabpanel" aria-labelledby="nav-tab-%1$s">', esc_attr( $section['id'] ) );
+			printf( '<section id="tab-%1$s" class="hide-if-js" role="tabpanel" aria-labelledby="nav-tab-%1$s">', esc_attr( $section['id'] ) );
 			if ( $section['title'] ) {
 				printf( '<h2>%1$s</h2>%2$s', esc_html( $section['title'] ), PHP_EOL );
 			}


### PR DESCRIPTION
## Added

* The tabbing JavaScript will now listen for `window.hashchange` events, enabling links within the tab content to change tabs (#13)
* Add `.tabbed-section-heading` to the `<h2>` at the top of each tabbed panel (#15)

## Fixed

* Prevent all the tabs from displaying on page load before the tab script executes (#14)